### PR TITLE
default to array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ### Fixed
 - `getSearchContent()` was incorrectly spelled `gtSearchContent()` in the `CanBeSearched` trait.
+- If the config does not contain a 'models' key, we will make sure we default to an array in the `IndexCommand`.
 
 ## [0.1.1] - 2017-06-04
 

--- a/src/Console/IndexCommand.php
+++ b/src/Console/IndexCommand.php
@@ -32,7 +32,7 @@ class IndexCommand extends Command
         $class = $this->argument('model');
 
         if (is_null($class)) {
-            $classes = config('search.models');
+            $classes = config('search.models', []);
         }
 
         else {


### PR DESCRIPTION
we except the `$classes` variable to be an array, so lets make sure if there is no corresponding 'models' key in the config, that we return an array.