### PR TITLE
drop support for old packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
+  - 7.1
+  - 7.2
 
 # This triggers builds to run on the new TravisCI infrastructure.
 # See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ### Changed
 - Rename the config file to `larasearch.php` to help avoid conflicts.
+- Moving forward with PHP7. No longer supporting older versions.
 
 ### Fixed
 - `getSearchContent()` was incorrectly spelled `gtSearchContent()` in the `CanBeSearched` trait.

--- a/composer.json
+++ b/composer.json
@@ -17,15 +17,15 @@
         }
     ],
     "require": {
-        "php": "~5.6|~7.0",
-        "illuminate/bus": "~5.0",
-        "illuminate/console": "~5.0",
-        "illuminate/queue": "~5.0",
-        "illuminate/support": "~5.0"
+        "php": ">=7.0",
+        "illuminate/bus": "~5.5",
+        "illuminate/console": "~5.5",
+        "illuminate/queue": "~5.5",
+        "illuminate/support": "~5.5"
     },
     "require-dev": {
         "elasticsearch/elasticsearch": "~5.0",
-        "phpunit/phpunit": "~4.0||~5.0||~6.0",
+        "phpunit/phpunit": "~5.0||~6.0",
         "squizlabs/php_codesniffer": "^2.3"
     },
     "autoload": {


### PR DESCRIPTION
- moving on to PHP7
- dropping PHPUnit 4
- Laravel 5.5